### PR TITLE
Remove chunk file cleanup step from script

### DIFF
--- a/sftp2blob_curl.sh
+++ b/sftp2blob_curl.sh
@@ -261,7 +261,6 @@ access_token=$(get_access_token "https://storage.azure.com/" "$MANAGED_IDENTITY_
 upload_file_in_chunks_to_azure_blob "$access_token" "$AZURE_STORAGE_ACCOUNT" "$AZURE_CONTAINER_NAME" "$AZURE_BLOB_NAME" "$LOCAL_FILE_PATH"
 
 # Cleanup (optional)
-rm -f "${LOCAL_FILE_PATH}.chunk.*"
 rm -f "$LOCAL_FILE_PATH"
 
 echo "File transfer completed successfully."


### PR DESCRIPTION
The script no longer removes individual chunk files after upload. This change ensures that only the main local file is deleted, preserving intermediate chunk files for further inspection if necessary.